### PR TITLE
check tableProperties is not undefined

### DIFF
--- a/src/converters/table.ts
+++ b/src/converters/table.ts
@@ -73,7 +73,7 @@ const generateTable = (
   };
   const tableProperties = generateTableProperties(tableElement, options);
   let defaultCellBorderProperties: DocumentBodyTableCellBlockProperties;
-  if (tableElement.attrs?.border === '1') {
+  if (tableElement.attrs?.border === '1' && tableProperties) {
     const borderWidth = tableProperties!.borderWidth;
     const borderStyle = tableProperties!.borderStyle;
     const borderColor = tableProperties!.borderColor;


### PR DESCRIPTION
if the style doesn't have a style attribute, generateTableProperties function will return undefined,    try to prevent call on borderWidth on undefined.