### PR TITLE
Support nested unordered lists

### DIFF
--- a/src/converters/list.ts
+++ b/src/converters/list.ts
@@ -189,6 +189,12 @@ const getFontType = (
   const children = listItemElement.children || [];
   for (let i = 0; i < children.length; i++) {
     if (children[i].type === DomNodeType.Tag) {
+      if (
+        children[i].name?.toLowerCase() === Tag.OrderedList ||
+        children[i].name?.toLowerCase() === Tag.UnorderedList
+      ) {
+        continue;
+      }
       const fontType = htmlTagToFontType(children[i].name);
       if (fontType) {
         return fontType;

--- a/test/convert-html-to-blocks/list/nested-lists/input.html
+++ b/test/convert-html-to-blocks/list/nested-lists/input.html
@@ -20,4 +20,14 @@
       </li>
     </ol>
   </li>
+  <li>
+    A list item with unordered list children
+    <ul>
+      <li>
+        This is a bullet point for list item3 with a <a target="_blank" title="https://example.com/" href="https://example.com/">link</a>&nbsp; and 
+        <span style="background-color: #f1c40f; color: #e03e2d;">formatting</span>
+      </li>
+      <li>This is a bullet point without formatting for list item3</li>
+    </ol>
+  </li>
 </ol>

--- a/test/convert-html-to-blocks/list/nested-lists/output.json
+++ b/test/convert-html-to-blocks/list/nested-lists/output.json
@@ -205,6 +205,69 @@
               }
             }
           ]
+        },
+        {
+          "type": "ListItem",
+          "blocks": [
+            {
+              "type": "Text",
+              "text": {
+                "text": "A list item with unordered list children"
+              }
+            },
+            {
+              "type": "UnorderedList",
+              "list": {
+                "blocks": [
+                  {
+                    "type": "ListItem",
+                    "blocks": [
+                      {
+                        "type": "Text",
+                        "text": {
+                          "text": "This is a bullet point for list item3 with a "
+                        }
+                      },
+                      {
+                        "type": "Text",
+                        "text": {
+                          "text": "link",
+                          "hyperlink": "https://example.com/"
+                        }
+                      },
+                      {
+                        "type": "Text",
+                        "text": {
+                          "text": "&nbsp; and "
+                        }
+                      },
+                      {
+                        "type": "Text",
+                        "text": {
+                          "text": "formatting",
+                          "properties": {
+                            "backgroundColor": "#f1c40f",
+                            "textColor": "#e03e2d"
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "ListItem",
+                    "blocks": [
+                      {
+                        "type": "Text",
+                        "text": {
+                          "text": "This is a bullet point without formatting for list item3"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
Having an ordered list with unordered children results in incorrect continuation of ordered list. Additional changes added to prevent this behaviour. 